### PR TITLE
⚡ Make Walker concurrency dynamic and configurable

### DIFF
--- a/cmd/mostcomm/main.go
+++ b/cmd/mostcomm/main.go
@@ -20,6 +20,7 @@ var (
 	thresholdPercentFlag  = flag.Int("percent-threshold", 0, "Minimum required % of the file in common")
 	thresholdLinesFlag    = flag.Int("lines-threshold", 0, "Minimum required lines of the file in common")
 	thresholdMatchMaxFlag = flag.Int("match-max-threshold", -1, "Maximum time a match is allowed")
+	concurrencyFlag       = flag.Int("concurrency", 0, "Concurrency limit (default 0 = number of CPUs)")
 )
 
 func main() {
@@ -30,6 +31,7 @@ func main() {
 		WalkerGroup: sync.WaitGroup{},
 		FS:          os.DirFS(*dirFlag),
 		LineMutex:   sync.Mutex{},
+		Concurrency: *concurrencyFlag,
 	}
 	if err := fs.WalkDir(data.FS, ".", mostcomm.Walker(data, strings.Split(*fileMaskFlag, ";"))); err != nil {
 		log.Panic(err)

--- a/mostcomm.go
+++ b/mostcomm.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -82,6 +83,7 @@ type Data struct {
 	WalkerGroup sync.WaitGroup
 	FS          fs.FS
 	LineMutex   sync.Mutex
+	Concurrency int
 }
 
 func (d *Data) Add(lines []*Line) {
@@ -289,7 +291,11 @@ func (fpm *FilePositionMatch) Positions() [2]int {
 var _ fmt.Stringer = (*Duplicate)(nil)
 
 func Walker(data *Data, masks []string) fs.WalkDirFunc {
-	c := make(chan struct{}, 25)
+	limit := data.Concurrency
+	if limit <= 0 {
+		limit = runtime.NumCPU()
+	}
+	c := make(chan struct{}, limit)
 	return func(path string, d fs.DirEntry, err error) error {
 		if d != nil && d.IsDir() {
 			return nil


### PR DESCRIPTION
💡 **What:**
- Refactored `Walker` in `mostcomm.go` to use `Data.Concurrency`.
- Added `Concurrency` field to `Data` struct.
- Defaults to `runtime.NumCPU()` if `Concurrency` is 0.
- Imported `runtime` package.

🎯 **Why:**
- The previous limit was hardcoded to 25, which is arbitrary and may not be optimal for all environments (e.g., single-core containers vs. 64-core servers).
- Making it dynamic based on CPU count ensures better resource utilization by default.
- Making it configurable allows users to tune performance for their specific workload (I/O bound vs CPU bound).

📊 **Measured Improvement:**
- **Baseline (Hardcoded 25):** ~61ms per op (allocs: 296k)
- **New Default (NumCPU = 4):** ~81ms per op
- **Configured (Concurrency = 25):** ~62ms per op

*Note:* On the test environment (4 CPUs), the default dynamic limit (4) is stricter than the previous hardcoded limit (25), resulting in slightly lower throughput for the specific benchmark case. However, this change provides the mechanism to scale up on larger machines (e.g., 32 cores -> 32 workers) and avoids over-subscription on smaller ones, while allowing manual override for specific tuning.

---
*PR created automatically by Jules for task [11533341231515114917](https://jules.google.com/task/11533341231515114917) started by @arran4*