### PR TITLE
Update Go to 1.24 and workflows

### DIFF
--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: false
       - name: Cache-Go
         uses: actions/cache@v4

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -18,6 +18,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
             - name: Install Go
               uses: actions/setup-go@v5
               with:
-                  go-version: "1.23"
+                  go-version: "1.24"
             - name: Cache-Go
               uses: actions/cache@v4
               with:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module mostcomm
 
-go 1.23
+go 1.24


### PR DESCRIPTION
Updated the project to use Go 1.24.
Updated GitHub workflows to use Go 1.24.
Ensured GitHub Actions are using up-to-date versions (v6 for golangci-lint-action and goreleaser-action).
Checked for dependency updates (none found as the project uses only standard library).

---
*PR created automatically by Jules for task [1191918187733082364](https://jules.google.com/task/1191918187733082364) started by @arran4*